### PR TITLE
Fork PR L2 error fix

### DIFF
--- a/.github/workflows/TriggerIntegrationTests.sh
+++ b/.github/workflows/TriggerIntegrationTests.sh
@@ -5,6 +5,7 @@ prNumber=$4
 frombranch=$5
 tobranch=$6
 patUser=$7
+fromRepo=$8
 
 getPayLoad() {
     cat <<EOF
@@ -18,6 +19,7 @@ getPayLoad() {
         "prNumber": "$prNumber", 
         "tobranch": "$tobranch", 
         "frombranch": "$frombranch"
+        "fromRepo": "$fromRepo"
     }
 }
 EOF

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,4 +18,4 @@ jobs:
             
         - name: Trigger Test run
           run: |
-            bash ./IntegrationTests/.github/workflows/TriggerIntegrationTests.sh ${{ secrets.L2_REPO_TOKEN }} ${{ github.event.pull_request.head.sha }} ${{ github.repository }} ${{ github.event.pull_request.number }} ${{ github.event.pull_request.head.ref }} ${{ github.event.pull_request.base.ref }} ${{ secrets.L2_REPO_USER }}
+            bash ./IntegrationTests/.github/workflows/TriggerIntegrationTests.sh ${{ secrets.L2_REPO_TOKEN }} ${{ github.event.pull_request.head.sha }} ${{ github.repository }} ${{ github.event.pull_request.number }} ${{ github.event.pull_request.head.ref }} ${{ github.event.pull_request.base.ref }} ${{ secrets.L2_REPO_USER }} ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
For PR raised from forked repo, the branch from the forked repo needs to be checked out.
Added the forked repo name as argument(fromRepo) to L2 script trigger repository_dispatch event call.